### PR TITLE
Allow {:system, NAME} format for environment variables in config files

### DIFF
--- a/lib/qdrant.ex
+++ b/lib/qdrant.ex
@@ -146,12 +146,12 @@ defmodule Qdrant do
 
   @doc """
   Delete multiple points that match filtering conditions
-  
+
   Parameters:
   * `collection_name` - name of the collection to search in
   * `body` - search body
   * `consistency` - Define read consistency guarentees for the operation
-  
+
   Example:
   ```elixir
   body = %{

--- a/lib/qdrant/api/http/client.ex
+++ b/lib/qdrant/api/http/client.ex
@@ -29,25 +29,33 @@ defmodule Qdrant.Api.Http.Client do
       defp base_url, do: "#{api_url()}:#{port()}#{api_path()}"
 
       defp api_url do
-        case Application.get_env(:qdrant, :database_url) do
+        case get_env_variable(:database_url) do
           nil -> raise "Qdrant database url is not set"
           base_url -> base_url
         end
       end
 
       defp port do
-        case Application.get_env(:qdrant, :port) do
+        case get_env_variable(:port) do
           nil -> raise "Qdrant database port is not set"
           port -> port
         end
       end
 
       defp api_key do
-        case Application.get_env(:qdrant, :api_key) do
+        case get_env_variable(:api_key) do
           nil -> raise "Qdrant api key is not set"
           api_key -> api_key
         end
       end
+
+      defp get_env_variable(key), do: parse_env_variable(Application.get_env(:qdrant, key))
+
+      defp parse_env_variable({:system, name}) do
+        System.get_env(name)
+      end
+
+      defp parse_env_variable(variable), do: variable
 
       import(Qdrant.Api.Http.Client, only: [scope: 1])
     end

--- a/test/qdrant/api/http/client_test.exs
+++ b/test/qdrant/api/http/client_test.exs
@@ -11,8 +11,27 @@ defmodule Qdrant.Api.Http.ClientTest do
 
   describe "base_url/0" do
     setup do
-      Application.put_env(:qdrant, :database_url, "http://localhost:6333")
+      Application.put_env(:qdrant, :database_url, "http://localhost")
+      Application.put_env(:qdrant, :port, "6333")
       :ok
+    end
+
+    test "returns the correct base url" do
+      assert base_url() == "http://localhost:6333/api/v1"
+    end
+
+    test "raises an error when the Qdrant database url is not set" do
+      Application.delete_env(:qdrant, :database_url)
+      assert_raise RuntimeError, "Qdrant database url is not set", &base_url/0
+    end
+  end
+
+  describe "Accept system environment variable formats" do
+    setup do
+      System.put_env("DATABASE_URL", "http://localhost")
+      System.put_env("PORT", "6333")
+      Application.put_env(:qdrant, :database_url, {:system, "DATABASE_URL"})
+      Application.put_env(:qdrant, :port, {:system, "PORT"})
     end
 
     test "returns the correct base url" do


### PR DESCRIPTION
In Phoenix we might not get the environment variables at compile time so we let the library get them from the environment variables rather than get it and pass it to the library.